### PR TITLE
fix(fill): proper handling custom receiver account

### DIFF
--- a/src/contracts/fusion-swap-contract.ts
+++ b/src/contracts/fusion-swap-contract.ts
@@ -180,7 +180,9 @@ export class FusionSwapContract {
                     // 3. maker_receiver
                     pubkey: order.receiver,
                     isSigner: false,
-                    isWritable: order.dstAssetIsNative
+                    isWritable:
+                        order.dstAssetIsNative ||
+                        !accounts.maker.equal(order.receiver)
                 },
                 {
                     // 4. src_mint


### PR DESCRIPTION
## Change Summary
**What does this PR change?**
There was a bug with order created with a custom receiver address. The `maker_receiver` account in such cases was not market is writable

## Testing & Verification
**How was this tested?**
- [ ] Unit tests
- [x] Integration tests
- [ ] Manual testing (describe steps)
- [ ] Verified on staging
<!-- Provide logs, screenshots, or steps to reproduce -->

## Risk Assessment
**Risk Level:**
- [x] **Low** - Minor changes, no operational impact
- [ ] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback
