### PR TITLE
ci(PT9-364): pin node to 22.14.0 in publish-to-npm workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 22.14.0
           registry-url: 'https://registry.npmjs.org'
           scope: ${{ github.repository_owner }}
           cache: pnpm

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solana-fusion-sdk",
-  "version": "0.1.17",
+  "version": "0.1.18-rc.0",
   "description": "SDK for fusion on Solana",
   "author": "@1inch",
   "license": "MIT",


### PR DESCRIPTION
## Change Summary
**What does this PR change?**
Pin node to 22.14.0 in publish-to-npm workflow

**Related Issue/Ticket:**
https://1inch.atlassian.net/browse/PT9-364

## Testing & Verification
**How was this tested?**
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe steps)
- [ ] Verified on staging
<!-- Provide logs, screenshots, or steps to reproduce -->

## Risk Assessment
**Risk Level:**
- [x] **Low** - Minor changes, no operational impact
- [ ] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback

**Risks & Impact**
<!-- Describe any possible risks, such as migrations, downtime, or breaking changes, etc. -->
